### PR TITLE
Move dind to sidecar for ROCm linux runners.

### DIFF
--- a/config-files/rocm/azure-linux-scale-rocm.yaml
+++ b/config-files/rocm/azure-linux-scale-rocm.yaml
@@ -5,73 +5,70 @@
 #
 ## To export:
 # helm get values azure-linux-scale-rocm -n arc-rocm-linux-runners -o yaml > cur_azure-linux-scale-rocm.yaml
-#
-## REDACT `github_app_private_key` or any keys if committing to repo!
-## TODO: ideally should be using secrets with `kubectl`
 
-githubConfigSecret:
-  github_app_id: "1166088"
-  github_app_installation_id: "62065164"
-  github_app_private_key: |
-    -----BEGIN RSA PRIVATE KEY-----
-    <redacted base64 key>
-    -----END RSA PRIVATE KEY-----
+githubConfigSecret: rocm-secret
 githubConfigUrl: https://github.com/ROCm
 minRunners: 1
 template:
   spec:
-    containers:
-    - command:
-      - /home/runner/run.sh
-      env:
-      - name: DOCKER_HOST
-        value: unix:///var/run/docker.sock
-      image: ghcr.io/saienduri/ghascale:main
-      imagePullPolicy: Always
-      name: runner
-      resources:
-        requests:
-          cpu: 40000m
-          memory: 50000Mi
-      volumeMounts:
-      - mountPath: /home/runner/_work
-        name: work
-      - mountPath: /var/run
-        name: dind-sock
-    - args:
-      - dockerd
-      - --host=unix:///var/run/docker.sock
-      - --group=$(DOCKER_GROUP_GID)
-      env:
-      - name: DOCKER_GROUP_GID
-        value: "123"
-      image: docker:dind
-      name: dind
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - mountPath: /home/runner/_work
-        name: work
-      - mountPath: /var/run
-        name: dind-sock
-      - mountPath: /home/runner/externals
-        name: dind-externals
     initContainers:
-    - command:
-      - cp
-      - -r
-      - /home/runner/externals/.
-      - /home/runner/tmpDir/
-      image: ghcr.io/saienduri/ghascale:main
-      imagePullPolicy: Always
-      name: init-dind-externals
-      volumeMounts:
-      - mountPath: /home/runner/tmpDir
-        name: dind-externals
+      - name: init-dind-externals
+        image: ghcr.io/saienduri/ghascale:main
+        imagePullPolicy: Always
+        command:
+          ["cp", "-r", "/home/runner/externals/.", "/home/runner/tmpDir/"]
+        volumeMounts:
+          - name: dind-externals
+            mountPath: /home/runner/tmpDir
+      - name: dind
+        image: ghcr.io/saienduri/dind:main
+        restartPolicy: Always
+        command: ["sh", "-c"]
+        args:
+          - |
+            dockerd --host=unix:///var/run/docker.sock --group=${DOCKER_GROUP_GID} &
+            until docker info >/dev/null 2>&1; do sleep 5; done
+            tail -f /dev/null
+        env:
+          - name: DOCKER_GROUP_GID
+            value: "123"
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: dind-sock
+            mountPath: /var/run
+          - name: dind-externals
+            mountPath: /home/runner/externals
+    containers:
+      - name: runner
+        image: ghcr.io/saienduri/ghascale:main
+        imagePullPolicy: Always
+        command:
+          - /bin/sh
+          - -c
+          - |
+            # Wait for Docker to be ready before starting runner
+            echo "Waiting for docker..."
+            until docker info >/dev/null 2>&1; do sleep 5; done
+            /home/runner/run.sh
+        resources:
+          requests:
+            cpu: 40000m
+            memory: 50000Mi
+        env:
+          - name: DOCKER_HOST
+            value: unix:///var/run/docker.sock
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: dind-sock
+            mountPath: /var/run
     volumes:
-    - emptyDir: {}
-      name: work
-    - emptyDir: {}
-      name: dind-sock
-    - emptyDir: {}
-      name: dind-externals
+      - name: work
+        emptyDir: {}
+      - name: dind-sock
+        emptyDir: {}
+      - name: dind-externals
+        emptyDir: {}


### PR DESCRIPTION
This addresses jobs failing because the docker daemon is not running.

See related issue: https://github.com/actions/actions-runner-controller/issues/3794, https://github.com/actions/actions-runner-controller/pull/3842