### PR TITLE
Double ephemeral-storage limits from 100 to 200Gi

### DIFF
--- a/windows-config-files/azure-windows-scale.yaml
+++ b/windows-config-files/azure-windows-scale.yaml
@@ -24,7 +24,7 @@ template:
       name: runner
       resources:
         limits:
-          ephemeral-storage: 100Gi
+          ephemeral-storage: 200Gi
           memory: 92Gi
         requests:
           ephemeral-storage: 10Gi
@@ -52,4 +52,3 @@ template:
       emptyDir: {}
     - name: azure-disk
       emptyDir: {}
-


### PR DESCRIPTION
As noted here https://github.com/iree-org/iree/issues/21792, there are some issues with running out of temporary storage space when building on IREE runners, doubling the limit from 100Gi to 200Gi
